### PR TITLE
Fix setup script whitespace

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,3 @@
-
-
 echo "Setting up JWT Service development environment..."
 
 if ! command -v deno &> /dev/null; then


### PR DESCRIPTION
## Summary
- remove stray blank lines at the start of `setup.sh`

## Testing
- `deno fmt setup.sh` *(fails: Unsupported lockfile version '4')*
- `deno task test` *(fails: Unsupported lockfile version '4')*