### PR TITLE
Add health path to OpenAPI

### DIFF
--- a/doc/jwt-service-openapi.yml
+++ b/doc/jwt-service-openapi.yml
@@ -87,3 +87,16 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string


### PR DESCRIPTION
## Summary
- document the `/health` endpoint in OpenAPI spec

## Testing
- `deno fmt --check` *(fails: Unsupported lockfile version)*
- `deno lint` *(fails: Unsupported lockfile version)*