### PR TITLE
Update Fly secret instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ global distribution.
    ```
    - This will create a `fly.toml` file in your project
 
-2. Configure secrets for your private keys and API keys:
+2. Configure secrets for your private keys and API keys. **Newline characters in
+   the PEM file must be preserved**:
    ```bash
-   fly secrets set PRIVATE_KEY_PEM="your-privateKey"
+   fly secrets set PRIVATE_KEY_PEM="$(cat path/to/private.pem)"
    fly secrets set API_KEY_CURRENT="your-secure-api-key"
    ```
 


### PR DESCRIPTION
## Summary
- document safe approach for setting secrets on Fly

## Testing
- `deno test --allow-net --allow-env --allow-run --no-lock --allow-read` *(fails: error sending request)*
- `deno task fmt` *(fails: Unsupported lockfile version)*
- `deno task lint` *(fails: Unsupported lockfile version)*