### PR TITLE
Fix key export on startup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,11 @@ let publicKey;
 
 try {
   if (PRIVATE_KEY_PEM) {
-    privateKey = await jose.importPKCS8(PRIVATE_KEY_PEM, "RS256");
+    privateKey = await jose.importPKCS8(
+      PRIVATE_KEY_PEM,
+      "RS256",
+      { extractable: true },
+    );
     console.log("Loaded private key from environment variable");
   } else {
     console.warn("No private key provided, generating a temporary key pair for development");


### PR DESCRIPTION
## Summary
- allow the imported private key to be extractable so the service can derive the public key when `PUBLIC_KEY_PEM` is not set

## Testing
- `deno task fmt` *(fails: Unsupported lockfile version)*
- `deno task lint` *(fails: Unsupported lockfile version)*
- `deno task test` *(fails: Unsupported lockfile version)*