### PR TITLE
Remove newlines from generated PEM output

### DIFF
--- a/cli/generate-private-key.ts
+++ b/cli/generate-private-key.ts
@@ -16,10 +16,10 @@ async function generateKeyPair(modulusLength: number): Promise<{
 }> {
   const { privateKey, publicKey } = await jose.generateKeyPair("RS256", {
     modulusLength,
-    extractable: true
+    extractable: true,
   });
-  const privatePem = await jose.exportPKCS8(privateKey);
-  const publicPem = await jose.exportSPKI(publicKey);
+  const privatePem = (await jose.exportPKCS8(privateKey)).replace(/\r?\n/g, "");
+  const publicPem = (await jose.exportSPKI(publicKey)).replace(/\r?\n/g, "");
   return { privateKey: privatePem, publicKey: publicPem };
 }
 


### PR DESCRIPTION
## Summary
- sanitize PEM strings in the generate-private-key CLI

## Testing
- `deno lint` *(fails: no-explicit-any in cli/test_nodes_from_json.ts)*
- `deno task test` *(fails to fetch remote modules: network unreachable)*